### PR TITLE
Add search oceanbase document tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.0.0",
     "mysql-connector-python>=9.1.0",
-    "python-dotenv"
+    "python-dotenv",
+    "beautifulsoup4>=4.13.3"
 ]
 
 [[project.authors]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "mcp[cli]>=1.0.0",
     "mysql-connector-python>=9.1.0",
     "python-dotenv",
-    "beautifulsoup4>=4.13.3"
+    "beautifulsoup4>=4.13.3",
+    "certifi>=2025.4.26",
 ]
 
 [[project.authors]]

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -283,8 +283,11 @@ def get_resource_capacity():
 @app.tool()
 def search_oceanbase_document(keyword: str) -> str:
     """
-    Query the relevant documentation of OceanBase if you have any doubts.
-    The parameters are the keywords you extract from the user's question or your answer.
+    This tool is designed to provide context-specific information about OceanBase to a large language model (LLM) to enhance the accuracy and relevance of its responses. The main functions of this tool include:
+    1.Keyword Extraction: The LLM automatically extracts relevant search keywords from user queries.
+    2.Information Retrieval: The MCP Tool searches through OceanBase-related documentation using the extracted keywords, locating and extracting the most relevant information.
+    3.Context Provision: The retrieved information from OceanBase documentation is then fed back to the LLM as contextual reference material. This context is not directly shown to the user but is used to refine and inform the LLM’s responses.
+    This tool ensures that when the LLM’s internal documentation is insufficient to generate high-quality responses, it dynamically retrieves necessary OceanBase information, thereby maintaining a high level of response accuracy and expertise.
     """
     logger.info(f"Calling tool: search_oceanbase_document,keyword:{keyword}")
     search_api_url = "https://cn-wan-api.oceanbase.com/wanApi/forum/docCenter/productDocFile/v3/searchDocList"

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -284,6 +284,7 @@ def search_oceanbase_document(keyword: str) -> str:
     Query the relevant documentation of OceanBase if you have any doubts.
     The parameters are the keywords you extract from the user's question or your answer.
     """
+    logger.info(f"Calling tool: search_oceanbase_document,keyword:{keyword}")
     search_url = "https://cn-wan-api.oceanbase.com/wanApi/forum/docCenter/productDocFile/v3/searchDocList"
     headers = {
         "Content-Type": "application/json",

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -315,7 +315,7 @@ def search_oceanbase_document(keyword: str) -> str:
                     + item["id"]
                 )
                 logger.info(f"doc_url:${doc_url}")
-                content = get_ob_doc_content(doc_url,item["id"])
+                content = get_ob_doc_content(doc_url, item["id"])
                 result_list.append(content)
             return json.dumps(result_list, ensure_ascii=False)
     except error.HTTPError as e:
@@ -326,8 +326,8 @@ def search_oceanbase_document(keyword: str) -> str:
         return "No results were found"
 
 
-def get_ob_doc_content(url: str,doc_id:str) -> dict:
-    doc_param = {"id": "1000000002016487", "url": url}
+def get_ob_doc_content(url: str, doc_id: str) -> dict:
+    doc_param = {"id": doc_id, "url": url}
     doc_param = json.dumps(doc_param).encode("utf-8")
     headers = {
         "Content-Type": "application/json",

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -284,7 +284,7 @@ def get_resource_capacity():
 def search_oceanbase_document(keyword: str) -> str:
     """
     This tool is designed to provide context-specific information about OceanBase to a large language model (LLM) to enhance the accuracy and relevance of its responses. 
-    The LLM should automatically extracts relevant search keywords from user queries or LLM's answer for the tool  parameter "keyword".
+    The LLM should automatically extracts relevant search keywords from user queries or LLM's answer for the tool parameter "keyword".
     The main functions of this tool include:
     1.Information Retrieval: The MCP Tool searches through OceanBase-related documentation using the extracted keywords, locating and extracting the most relevant information.
     2.Context Provision: The retrieved information from OceanBase documentation is then fed back to the LLM as contextual reference material. This context is not directly shown to the user but is used to refine and inform the LLM’s responses.

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -315,7 +315,7 @@ def search_oceanbase_document(keyword: str) -> str:
                     + item["id"]
                 )
                 logger.info(f"doc_url:${doc_url}")
-                content = get_ob_doc_content(doc_url)
+                content = get_ob_doc_content(doc_url,item["id"])
                 result_list.append(content)
             return json.dumps(result_list, ensure_ascii=False)
     except error.HTTPError as e:
@@ -326,7 +326,7 @@ def search_oceanbase_document(keyword: str) -> str:
         return "No results were found"
 
 
-def get_ob_doc_content(url: str) -> dict:
+def get_ob_doc_content(url: str,doc_id:str) -> dict:
     doc_param = {"id": "1000000002016487", "url": url}
     doc_param = json.dumps(doc_param).encode("utf-8")
     headers = {

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -283,10 +283,11 @@ def get_resource_capacity():
 @app.tool()
 def search_oceanbase_document(keyword: str) -> str:
     """
-    This tool is designed to provide context-specific information about OceanBase to a large language model (LLM) to enhance the accuracy and relevance of its responses. The main functions of this tool include:
-    1.Keyword Extraction: The LLM automatically extracts relevant search keywords from user queries.
-    2.Information Retrieval: The MCP Tool searches through OceanBase-related documentation using the extracted keywords, locating and extracting the most relevant information.
-    3.Context Provision: The retrieved information from OceanBase documentation is then fed back to the LLM as contextual reference material. This context is not directly shown to the user but is used to refine and inform the LLM’s responses.
+    This tool is designed to provide context-specific information about OceanBase to a large language model (LLM) to enhance the accuracy and relevance of its responses. 
+    The LLM should automatically extracts relevant search keywords from user queries or LLM's answer for the tool  parameter "keyword".
+    The main functions of this tool include:
+    1.Information Retrieval: The MCP Tool searches through OceanBase-related documentation using the extracted keywords, locating and extracting the most relevant information.
+    2.Context Provision: The retrieved information from OceanBase documentation is then fed back to the LLM as contextual reference material. This context is not directly shown to the user but is used to refine and inform the LLM’s responses.
     This tool ensures that when the LLM’s internal documentation is insufficient to generate high-quality responses, it dynamically retrieves necessary OceanBase information, thereby maintaining a high level of response accuracy and expertise.
     """
     logger.info(f"Calling tool: search_oceanbase_document,keyword:{keyword}")


### PR DESCRIPTION
增加了一个从ob的官网搜索ob文档的工具，在回答oceanbase相关问题时，先从ob的官网上搜索一下文档，在进行回答
有这个工具的回答结果：
![image](https://github.com/user-attachments/assets/883d4545-46ba-4117-b6ad-3d94ab8c63c3)
没有这个工具的回答结果：
![image](https://github.com/user-attachments/assets/c5be79e5-8d79-4650-9294-86184f0886dc)

