### PR TITLE
Optimize: Add host address configuration and optimize the startup method

### DIFF
--- a/doc/oceanbase_mcp_server.md
+++ b/doc/oceanbase_mcp_server.md
@@ -22,22 +22,28 @@ This server allows AI assistants to list tables, read data, and execute SQL quer
 
 ## Install
 
+### Clone the repository
 ```bash
-# Clone the repository
 git clone https://github.com/oceanbase/mcp-oceanbase.git
 cd mcp-oceanbase
-
-# Install the Python package manager uv and create virtual environment
+```
+### Install the Python package manager uv and create virtual environment
+```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv
 source .venv/bin/activate  # or `.venv\Scripts\activate` on Windows
-
-# If you configure the OceanBase connection information using .env file. You should copy .env.template to .env and modify .env
+```
+### If you configure the OceanBase connection information using .env file. You should copy .env.template to .env and modify .env
+```bash
 cp .env.template .env
-
-# Install dependencies
+```
+### If the dependency packages cannot be downloaded via UV due to network issues, you can change the mirror source to the Alibaba Cloud mirror source.
+```bash
+export UV_DEFAULT_INDEX="https://mirrors.aliyun.com/pypi/simple/"
+```
+### Install dependencies
+```bash
 uv pip install .
-
 ```
 ## Configuration
 There are two ways to configure the connection information of OceanBase
@@ -81,10 +87,15 @@ Add the following content to the configuration file that supports the MCP server
 ```
 ### SSE Mode
 Within the mcp-oceanbase directory, execute the following command, the port can be customized as desired.<br>
-'--transport': Specify the MCP server transport type as stdio or sse, default is stdio.<br>
-'--port': Specify sse port to listen on, default is 8000
+'--transport': MCP server transport type as stdio or sse, default is stdio.<br>
+'--host': SSE Host to bind to, default is 127.0.0.1, that is to say, you can only access it on your local computer.If you want any client to be able to access it, you can set the host to 0.0.0.0.
+'--port': sse port to listen on, default is 8000
 ```bash
 uv run oceanbase_mcp_server --transport sse --port 8000
+```
+If you don't want to use uv, you can start it in the following way:
+```bash
+cd src/oceanbase_mcp_server/ && python3 -m server --transport sse --port 9000
 ```
 
 ## Security Considerations

--- a/doc/oceanbase_mcp_server.md
+++ b/doc/oceanbase_mcp_server.md
@@ -87,13 +87,13 @@ Add the following content to the configuration file that supports the MCP server
 ```
 ### SSE Mode
 Within the mcp-oceanbase directory, execute the following command, the port can be customized as desired.<br>
-'--transport': MCP server transport type as stdio or sse, default is stdio.<br>
-'--host': SSE Host to bind to, default is 127.0.0.1, that is to say, you can only access it on your local computer.If you want any client to be able to access it, you can set the host to 0.0.0.0.
+'--transport': MCP server transport type as stdio or sse, default is stdio<br>
+'--host': sse Host to bind to, default is 127.0.0.1, that is to say, you can only access it on your local computer. If you want any remote client to be able to access it, you can set the host to 0.0.0.0<br>
 '--port': sse port to listen on, default is 8000
 ```bash
 uv run oceanbase_mcp_server --transport sse --port 8000
 ```
-If you don't want to use uv, you can start it in the following way:
+If you don't want to use uv, you can start it in the following way
 ```bash
 cd src/oceanbase_mcp_server/ && python3 -m server --transport sse --port 9000
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@ mcp>=1.0.0
 fastmcp>=1.0.0
 mysql-connector-python>=9.1.0
 python-dotenv
+beautifulsoup4>=4.13.3
+certifi>=2025.4.26
 requests
+

--- a/src/oceanbase_mcp_server/__init__.py
+++ b/src/oceanbase_mcp_server/__init__.py
@@ -1,22 +1,9 @@
 from . import server
-import argparse
 
 
 def main():
     """Main entry point for the package."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--transport",
-        type=str,
-        default="stdio",
-        help="Specify the MCP server transport type as stdio or sse.",
-    )
-    parser.add_argument("--port", type=int, default=8000, help="SSE Port to listen on")
-    args = parser.parse_args()
-    if args.transport == "stdio":
-        server.main()
-    else:
-        server.main(transport="sse", port=args.port)
+    server.main()
 
 
 # Expose important items at package level

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -4,7 +4,7 @@ import time
 from typing import Dict, Literal, Optional
 from urllib import request, error
 import json
-
+import argparse
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from mysql.connector import Error, connect
@@ -390,12 +390,25 @@ def get_ob_doc_content(doc_url: str, doc_id: str) -> dict:
         return {"result": "No results were found"}
 
 
-def main(transport: Literal["stdio", "sse"] = "stdio", port: int = 8000):
+def main():
     """Main entry point to run the MCP server."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--transport",
+        type=str,
+        default="stdio",
+        help="Specify the MCP server transport type as stdio or sse.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="SSE Host to bind to")
+    parser.add_argument("--port", type=int, default=8000, help="SSE Port to listen on")
+    args = parser.parse_args()
+    transport = args.transport
     logger.info(f"Starting OceanBase MCP server with {transport} mode...")
-    app.settings.port = port
+    if transport == "sse":
+        app.settings.host = args.host
+        app.settings.port = args.port
     app.run(transport=transport)
 
 
 if __name__ == "__main__":
-    app.run()
+    main()

--- a/src/oceanbase_mcp_server/server.py
+++ b/src/oceanbase_mcp_server/server.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from typing import Dict, Literal, Optional
+from typing import Dict, Optional
 from urllib import request, error
 import json
 import argparse


### PR DESCRIPTION
Added the host configuration option and refined the startup method and documentation.
Both of the following startup methods are OK.
## use uv
```bash
uv run oceanbase_mcp_server --transport sse --host 0.0.0.0 --port 15603
```
![image](https://github.com/user-attachments/assets/3be9fc81-1848-4cf0-98d2-0da837479475)

## use python3 itself
```bash
cd src/oceanbase_mcp_server/ && python3 -m server --transport sse --host 0.0.0.0 --port 15603
```
![image](https://github.com/user-attachments/assets/acd70351-908a-45c7-8562-f18ad135aff4)
