### PR TITLE
chore(powermem-mcp): bump version to 1.1.3

### DIFF
--- a/src/powermem_mcp_server/README.md
+++ b/src/powermem_mcp_server/README.md
@@ -4,6 +4,20 @@ PowerMem MCP Server - Model Context Protocol server for PowerMem memory manageme
 
 English | [简体中文](powermem_mcp_server_CN.md)
 
+## Installation
+
+Run directly with `uvx`; the published `powermem-mcp` package installs the required PowerMem runtime dependencies automatically.
+
+```shell
+uvx powermem-mcp --help
+```
+
+For a persistent local installation:
+
+```shell
+pip install powermem-mcp
+```
+
 ## Startup
 
 ### Support for multiple types of MCP

--- a/src/powermem_mcp_server/powermem_mcp_server_CN.md
+++ b/src/powermem_mcp_server/powermem_mcp_server_CN.md
@@ -4,16 +4,25 @@ PowerMem MCP Server - 用于 PowerMem 内存管理的模型上下文协议服务
 
 [English](README.md) | 简体中文
 
+## 安装
+
+推荐直接使用 `uvx` 运行；发布后的 `powermem-mcp` 包会自动安装所需的 PowerMem 运行依赖。
+
+```shell
+uvx powermem-mcp --help
+```
+
+如果需要固定安装到本地环境：
+
+```shell
+pip install powermem-mcp
+```
+
 ## 前置条件
 
 在使用 PowerMem MCP Server 之前，请确保：
 
-1. **已安装 PowerMem**：服务器需要 PowerMem 已安装。您可以通过以下方式安装：
-   ```shell
-   pip install powermem
-   ```
-
-2. **配置文件存在**：在工作目录或项目根目录创建 `.env` 文件，包含 PowerMem 配置。服务器会自动在以下位置搜索 `.env` 文件：
+1. **配置文件存在**：在工作目录或项目根目录创建 `.env` 文件，包含 PowerMem 配置。服务器会自动在以下位置搜索 `.env` 文件：
    - 当前工作目录的 `.env`
    - 项目根目录的 `.env`
    - `examples/configs/.env`

--- a/src/powermem_mcp_server/pyproject.toml
+++ b/src/powermem_mcp_server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem-mcp"
-version = "0.2.0"
+version = "1.1.3"
 description = "PowerMem MCP Server - Model Context Protocol server for PowerMem memory management"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -35,7 +35,7 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "powermem>=0.2.0",
+    "powermem[mcp,seekdb]==1.1.3",
     "fastmcp>=1.0",
     "uvicorn>=0.27.1",
     "tomli>=1.2.0; python_version < '3.11'",
@@ -69,4 +69,3 @@ powermem-mcp = "powermem_mcp.server:main"
 packages = {find = {}}
 include-package-data = true
 zip-safe = false
-

--- a/src/powermem_mcp_server/pyproject.toml
+++ b/src/powermem_mcp_server/pyproject.toml
@@ -36,9 +36,6 @@ keywords = [
 requires-python = ">=3.10"
 dependencies = [
     "powermem[mcp,seekdb]==1.1.3",
-    "fastmcp>=1.0",
-    "uvicorn>=0.27.1",
-    "tomli>=1.2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/powermem_mcp_server/setup.py
+++ b/src/powermem_mcp_server/setup.py
@@ -38,7 +38,7 @@ def get_requirements():
         except ImportError:
             # Manual fallback for Python 3.10
             requirements = [
-                "powermem>=0.1.0",
+                "powermem[mcp,seekdb]==1.1.3",
                 "fastmcp>=1.0",
                 "uvicorn>=0.27.1",
             ]
@@ -47,7 +47,7 @@ def get_requirements():
 
 setup(
     name="powermem-mcp",
-    version="0.1.0",
+    version="1.1.3",
     description="PowerMem MCP Server - Model Context Protocol server for PowerMem memory management",
     long_description=read_readme(),
     long_description_content_type="text/markdown",

--- a/src/powermem_mcp_server/setup.py
+++ b/src/powermem_mcp_server/setup.py
@@ -39,8 +39,6 @@ def get_requirements():
             # Manual fallback for Python 3.10
             requirements = [
                 "powermem[mcp,seekdb]==1.1.3",
-                "fastmcp>=1.0",
-                "uvicorn>=0.27.1",
             ]
     return requirements
 


### PR DESCRIPTION
Bump powermem-mcp metadata to 1.1.3 and pin the dependency to powermem[mcp,seekdb]==1.1.3.\n\nThis follows the existing awesome-oceanbase-mcp release flow: create a powermem-mcp-v1.1.3 release from the upstream repository after merge, which triggers .github/workflows/publish.yaml for PyPI trusted publishing.